### PR TITLE
Fix compatibility with strict db mode for boolean values

### DIFF
--- a/src/Resources/contao/dca/tl_mvo_facebook.php
+++ b/src/Resources/contao/dca/tl_mvo_facebook.php
@@ -183,7 +183,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook'] =
                                 return '1' === $value;
                             },
                         ],
-                        'sql' => ['type' => 'boolean', 'default' => false]
+                        'sql' => ['type' => 'boolean', 'default' => false],
                     ],
                 'upload_directory' => [
                         'label' => &$GLOBALS['TL_LANG']['tl_mvo_facebook']['upload_directory'],

--- a/src/Resources/contao/dca/tl_mvo_facebook.php
+++ b/src/Resources/contao/dca/tl_mvo_facebook.php
@@ -175,7 +175,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook'] =
                 'import_enabled' => [
                         'label' => &$GLOBALS['TL_LANG']['tl_mvo_facebook']['import_enabled'],
                         'exclude' => true,
-                        'default' => false,
+                        'default' => 0,
                         'inputType' => 'checkbox',
                         'eval' => ['isBoolean' => true],
                         'save_callback' => [
@@ -183,6 +183,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook'] =
                                 return '1' === $value;
                             },
                         ],
+                        'sql' => ['type' => 'boolean', 'default' => false]
                     ],
                 'upload_directory' => [
                         'label' => &$GLOBALS['TL_LANG']['tl_mvo_facebook']['upload_directory'],

--- a/src/Resources/contao/dca/tl_mvo_facebook_event.php
+++ b/src/Resources/contao/dca/tl_mvo_facebook_event.php
@@ -100,7 +100,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook_event'] =
                 'visible' => [
                         'inputType' => 'checkbox',
                         'eval' => ['isBoolean' => true],
-                        'sql' => ['type' => 'boolean', 'default' => false]
+                        'sql' => ['type' => 'boolean', 'default' => false],
                     ],
                 'fb_event_id' => [],
                 'start_time' => [],

--- a/src/Resources/contao/dca/tl_mvo_facebook_event.php
+++ b/src/Resources/contao/dca/tl_mvo_facebook_event.php
@@ -100,6 +100,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook_event'] =
                 'visible' => [
                         'inputType' => 'checkbox',
                         'eval' => ['isBoolean' => true],
+                        'sql' => ['type' => 'boolean', 'default' => false]
                     ],
                 'fb_event_id' => [],
                 'start_time' => [],

--- a/src/Resources/contao/dca/tl_mvo_facebook_post.php
+++ b/src/Resources/contao/dca/tl_mvo_facebook_post.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook_post'] =
                 'visible' => [
                         'inputType' => 'checkbox',
                         'eval' => ['isBoolean' => true],
-                        'sql' => ['type' => 'boolean', 'default' => false]
+                        'sql' => ['type' => 'boolean', 'default' => false],
                     ],
                 'fb_post_id' => [],
                 'type' => [],

--- a/src/Resources/contao/dca/tl_mvo_facebook_post.php
+++ b/src/Resources/contao/dca/tl_mvo_facebook_post.php
@@ -99,6 +99,7 @@ $GLOBALS['TL_DCA']['tl_mvo_facebook_post'] =
                 'visible' => [
                         'inputType' => 'checkbox',
                         'eval' => ['isBoolean' => true],
+                        'sql' => ['type' => 'boolean', 'default' => false]
                     ],
                 'fb_post_id' => [],
                 'type' => [],


### PR DESCRIPTION
Fix Issue: #36 

Finally I found a solution for #36 ☺️ 

The `'default' => 0,` needs to be an `integer` in the dca - boolean is not working!
And as @fritzmg said we should add `'sql' => ['type' => 'boolean', 'default' => false]` to the dca.
The `save_callback` could be removed but I was not really sure - it's working without, too!